### PR TITLE
round flag step#2

### DIFF
--- a/src/components/GameRoundFlag/GameRoundFlag.tsx
+++ b/src/components/GameRoundFlag/GameRoundFlag.tsx
@@ -88,12 +88,20 @@ function GameRoundFlag({
           className="grid image-grid justify-items-stretch grid-cols-2"
         >
           {Array.from({ length: numFlagsToShow }, (_, i) => {
-            // todo: i0 to ensure that myPotList[i0.. +6] to contains gameState.potCode
+            // todo: extract these out
+            // note: i0 is to ensure that myPotList[i0.. +6] to contains gameState.potCode
+            // class...  transition-transform duration-500 ease-in
             const i0: number =
               myPotList.indexOf(gameState.potCode) < numFlagsToShow
                 ? 0
                 : myPotList.indexOf(gameState.potCode) - 4;
-            const aPot: PotCode = myPotList[i0 + i] as PotCode;
+            const i1 = (i0 + i) % myPotList.length;
+            const aPot: PotCode = myPotList[i1] as PotCode;
+            const myBorder: string = !guesses.includes(aPot)
+              ? "border-4 border-black"
+              : aPot === gameState.potCode
+                ? "border-4 border-green-700"
+                : "border-4 border-red-600";
             const bgColor: string =
               aPot === gameState.potCode
                 ? getColorOfStatus("won")
@@ -105,7 +113,7 @@ function GameRoundFlag({
                 <img
                   src={getPotFlagSvgUrl(aPot)}
                   alt={`flag of a pot:${i}:${aPot}`}
-                  className="max-h-52 m-auto p-1 my-5 transition-transform duration-500 ease-in h-20"
+                  className={`max-h-52 m-auto p-1 my-5 h-20 ${myBorder}`}
                   onClick={handleFlagGuessClicked}
                   id={`guess-${aPot}`}
                 />
@@ -113,7 +121,7 @@ function GameRoundFlag({
                   <div />
                 ) : (
                   <p className={`visible rounded-2xl -m-1 bg-${bgColor}`}>
-                    {dataBank[myPotList[i0 + i] as PotCode].name}
+                    {dataBank[myPotList[i1] as PotCode].name}
                   </p>
                 )}
               </div>

--- a/src/test/utils/utils.test.ts
+++ b/src/test/utils/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  getBgOfStatus,
+  getColorOfStatus,
   getDirectionEmoji,
   getDistanceWithUnitBySetting,
   getPotFlagSvgUrl,
@@ -114,16 +114,16 @@ describe("getPotFlagSvgUrl returns the href of the flag SVG of the given potCode
   });
 });
 
-describe("getBgOfStatus returns the correct class name based on status", () => {
+describe("getColorOfStatus returns the correct class name based on status", () => {
   it("should return the correct value when the game is in progress", () => {
-    expect(getBgOfStatus("pending")).toBe("bg-gray-500");
+    expect(getColorOfStatus("pending")).toBe("gray-500");
   });
 
   it("should return the correct value when the game was lost", () => {
-    expect(getBgOfStatus("lost")).toBe("bg-red-600");
+    expect(getColorOfStatus("lost")).toBe("red-600");
   });
 
   it("should return the correct value when the game was won", () => {
-    expect(getBgOfStatus("won")).toBe("bg-green-700");
+    expect(getColorOfStatus("won")).toBe("green-700");
   });
 });

--- a/src/utils/dataBank.ts
+++ b/src/utils/dataBank.ts
@@ -152,12 +152,12 @@ export function getPotCode(potName: string): string {
   return "invalid";
 }
 
-function getCurrentDateString(): string {
+export function getCurrentDateString(): string {
   const today = new Date();
   const year = today.getFullYear();
   const month = today.getMonth() + 1;
   const day = today.getDate();
-  return `${year}-${month}-${day}`;
+  return `${year}-0${month}-0${day}`;
 }
 
 function hashString(str: string): number {
@@ -171,6 +171,12 @@ function hashString(str: string): number {
   return hash;
 }
 
+export function getPseudoRandomNumber(): number {
+  const dateString = getCurrentDateString();
+  const hash = hashString(dateString);
+  return Math.abs(hash);
+}
+
 export function getTodaysPotCodeIndex(): number {
   const dateString = getCurrentDateString();
   const hash = hashString(dateString);
@@ -182,7 +188,7 @@ export function getTodaysPotCode(): string {
 }
 
 export function getPseudoRandomPotCode(n: number): string {
-  const idx2 = (getTodaysPotCodeIndex() + n) % potCodes.length;
+  const idx2 = (getTodaysPotCodeIndex() + n) % potCodes.length; // TODO: improve or delete
   return potCodes[idx2];
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -87,12 +87,12 @@ export function getPotFlagSvgUrl(potCode: PotCode): string {
   ).href;
 }
 
-export function getBgOfStatus(currentRoundStatus: GameRoundStatus): string {
+export function getColorOfStatus(currentRoundStatus: GameRoundStatus): string {
   return currentRoundStatus === "won"
-    ? "bg-green-700"
+    ? "green-700"
     : currentRoundStatus === "lost"
-      ? "bg-red-600"
-      : "bg-gray-500";
+      ? "red-600"
+      : "gray-500";
 }
 
 // =================== deprecated functions with no usage =================== //

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,4 +32,17 @@ export default {
     },
   },
   plugins: [],
+  /** check if safelist really needed, colors seemed to "get lost" sporadically */
+  purge: {
+    content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
+    options: {
+      safelist: [
+        "border-green-700",
+        "border-red-600",
+        "bg-green-700",
+        "bg-red-600",
+        "bg-gray-500",
+      ],
+    },
+  },
 };


### PR DESCRIPTION
preview deployed
- flags pseudo-randomized (pot-list shuffle based on daystring-hash)
- selected flag added border as response
- end of round pot-name background color set