### PR TITLE
Poc direction calculate

### DIFF
--- a/src/components/GameRoundPot/GameRoundPot.tsx
+++ b/src/components/GameRoundPot/GameRoundPot.tsx
@@ -71,6 +71,8 @@ function GameRoundPot({
     setCurrentGuess("");
   }, [guesses]);
 
+  //TODO
+
   const handleFormSubmission = (event: FormEvent<HTMLFormElement>): void => {
     event.preventDefault();
 

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -52,41 +52,49 @@ export function calculateDirection(
   return directionsFromTo[from][to] as CardinalDirection;
 }
 
-// =================== deprecated functions with no usage =================== //
-/*
-export function calculateDirectionOf(
-  from: string,
-  to: string
-): CardinalDirection {
-  // LOVAS.contains
-  return calculateDirection(
-    dataBank[from].coordinates,
-    dataBank[to].coordinates
-  );
+// angles unbalanced uneven to improve "human readable directions"
+// prettier-ignore
+const dirCodes15: CardinalDirection[] = [ "NW", "N", "NE",      // N-ish
+                                          "NE", "NE","NE",
+                                          "NE", "E", "SE",      // E-ish
+                                          "SE", "SE", "SE",
+                                          "SE", "S", "SW",      // S-ish
+                                          "SW", "SW", "SW",
+                                          "SW", "W", "NW" ]; // W-ish
+export function angle15ToDir(angle: number): CardinalDirection {
+  return dirCodes15[Math.floor(((angle + 15) % 360) / 15)];
 }
 
-// ChatGpt code, to be reviewed, to be used in the arrow-angle
+const dirCodes45: CardinalDirection[] = [
+  "N",
+  "NE",
+  "E",
+  "SE",
+  "S",
+  "SW",
+  "W",
+  "NW",
+];
+export function angle45ToDir(angle: number): CardinalDirection {
+  return dirCodes45[Math.floor(((angle + 22.5) % 360) / 45)];
+}
+
 function toRadians(degrees: number): number {
   return degrees * (Math.PI / 180);
 }
-
-export function calculateBearing(
-  pos1: { lat: number; lon: number },
-  pos2: { lat: number; lon: number }
-): number {
-  const lat1 = toRadians(pos1.lat);
-  const lat2 = toRadians(pos2.lat);
-  const deltaLon = toRadians(pos2.lon - pos1.lon);
+function toDegrees(radians: number): number {
+  return radians * (180 / Math.PI);
+}
+export function calculateAngle(pos1: Coordinates, pos2: Coordinates): number {
+  const lat1 = toRadians(pos1.latitude);
+  const lat2 = toRadians(pos2.latitude);
+  const deltaLon = toRadians(pos2.longitude - pos1.longitude);
 
   const y = Math.sin(deltaLon) * Math.cos(lat2);
   const x =
     Math.cos(lat1) * Math.sin(lat2) -
     Math.sin(lat1) * Math.cos(lat2) * Math.cos(deltaLon);
-  const theta = Math.atan2(y, x);
 
-  // Convert from radians to degrees
-  const bearing = (theta * (180 / Math.PI) + 360) % 360;
-
-  return bearing;
+  const bearing = Math.atan2(y, x);
+  return (toDegrees(bearing) + 360) % 360; // Normalize to 0-360 degrees
 }
-*/

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -54,13 +54,14 @@ export function calculateDirection(
 
 // angles unbalanced uneven to improve "human readable directions"
 // prettier-ignore
-const dirCodes15: CardinalDirection[] = [ "NW", "N", "NE",      // N-ish
-                                          "NE", "NE","NE",
-                                          "NE", "E", "SE",      // E-ish
+const dirCodes15: CardinalDirection[] = [ "NW", "N",  "NE",      // N-ish
+                                          "NE", "NE", "NE",
+                                          "NE", "E",  "SE",      // E-ish
                                           "SE", "SE", "SE",
-                                          "SE", "S", "SW",      // S-ish
+                                          "SE", "S",  "SW",      // S-ish
                                           "SW", "SW", "SW",
-                                          "SW", "W", "NW" ]; // W-ish
+                                          "SW", "W",  "NW",
+                                          "NW", "NW", "NW"]; // W-ish
 export function angle15ToDir(angle: number): CardinalDirection {
   return dirCodes15[Math.floor(((angle + 15) % 360) / 15)];
 }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -71,19 +71,19 @@ export function getDirectionEmoji(
   fromGuess: PotCode,
   toSolution: PotCode
 ): string {
-  const direction: CardinalDirection = calculateDirection(
-    fromGuess,
-    toSolution
-  );
+  if (fromGuess === toSolution) {
+    return directionEmojiMap.get("*") as string;
+  }
   const angle: number = calculateAngle(
     dataBank[fromGuess].coordinates,
     dataBank[toSolution].coordinates
   );
-  return (
-    (directionEmojiMap.get(direction) as string) +
-    " : " +
-    directionEmojiMap.get(angle15ToDir(angle))
-  );
+  return directionEmojiMap.get(angle15ToDir(angle)) as string;
+  // const direction: CardinalDirection = calculateDirection(
+  //   fromGuess,
+  //   toSolution
+  // );
+  // return directionEmojiMap.get(direction) as string;
 }
 
 export function getPotMapSvgUrl(potCode: PotCode): string {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -71,6 +71,7 @@ export function getDirectionEmoji(
     toSolution
   );
   return directionEmojiMap.get(direction) as string;
+  //return directionEmojiMap.get(angle15ToDir(calculateAngle(dataBank[fromGuess].coordinates,dataBank[toSolution].coordinates)));
 }
 
 export function getPotMapSvgUrl(potCode: PotCode): string {
@@ -94,66 +95,3 @@ export function getColorOfStatus(currentRoundStatus: GameRoundStatus): string {
       ? "red-600"
       : "gray-500";
 }
-
-// =================== deprecated functions with no usage =================== //
-/*
-export function calculateDistance(
-  solutionCode: string,
-  guessCode: string
-): number {
-  console.log(`calculateDistance(${solutionCode}, ${guessCode})`);
-  if (solutionCode === "" || guessCode === "") {
-    return 0;
-  }
-  return calculateDistanceInKm(
-    dataBank[solutionCode].coordinates,
-    dataBank[guessCode].coordinates
-  );
-}
-
-export function getDirectionFromSolution(
-  solutionCode: string,
-  guessCode: string
-): string {
-  console.log(`getDirectionFromSolution(${solutionCode}, ${guessCode})`);
-  if (solutionCode === "" || guessCode == "") {
-    // TODO: write a nicer input validation
-    return "*";
-  }
-
-  const dir = calculateDirectionOf(solutionCode, guessCode);
-  return directionEmojiMap.get(dir) || "*";
-}
-*/
-
-/*
-export const arrowImageUrl: string = new URL(
-  "../assets/misc/arrow-up.png",
-  import.meta.url
-).href;
-
-const directionImgRotate = new Map<string, number>([
-  //: Record<string, string> = {
-  ["N", 0],
-  ["S", 180],
-  ["W", 270],
-  ["E", 90],
-  ["NW", 315],
-  ["NE", 45],
-  ["SW", 225],
-  ["SE", 135],
-  ["*", 0],
-]);
-
-export function getImgRotateFromSolution(
-  solutionCode: string,
-  guessCode: string
-): number {
-  const dir = calculateDirectionOf(solutionCode, guessCode);
-  return directionImgRotate.get(dir) || 0;
-}
-
-export function getCssRotate(angle: number): string {
-  return `rotate-${angle}`;
-}
-*/

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,6 +1,11 @@
 import accentsMap from "./accentsMap.ts";
 import dataBank, { potNames } from "./dataBank.ts";
-import { calculateDirection, calculateDistanceInKm } from "./geo.ts";
+import {
+  calculateDirection,
+  calculateDistanceInKm,
+  angle15ToDir,
+  calculateAngle,
+} from "./geo.ts";
 import { CardinalDirection, GameRoundStatus, PotCode } from "../types/data.ts";
 
 // TODO some UI or i18n module
@@ -70,8 +75,15 @@ export function getDirectionEmoji(
     fromGuess,
     toSolution
   );
-  return directionEmojiMap.get(direction) as string;
-  //return directionEmojiMap.get(angle15ToDir(calculateAngle(dataBank[fromGuess].coordinates,dataBank[toSolution].coordinates)));
+  const angle: number = calculateAngle(
+    dataBank[fromGuess].coordinates,
+    dataBank[toSolution].coordinates
+  );
+  return (
+    (directionEmojiMap.get(direction) as string) +
+    " : " +
+    directionEmojiMap.get(angle15ToDir(angle))
+  );
 }
 
 export function getPotMapSvgUrl(potCode: PotCode): string {


### PR DESCRIPTION
POC for angle calculation to replace hard-coded angles
360deg splitted to 24 (8*3) directions to weigh in favor of NW/NE/SE/SW