### PR TITLE
fixing 'direction bug' to use common-sense directions, not the geo

### DIFF
--- a/src/test/utils/geo.test.ts
+++ b/src/test/utils/geo.test.ts
@@ -21,7 +21,7 @@ describe("test distance calculation", () => {
   it("should return the distance in meters between two pots", () => {
     const from: Coordinates = dataBank.bc.coordinates;
     const to: Coordinates = dataBank.sk.coordinates;
-    expect(calculateDistanceInMeters(from, to)).toBeCloseTo(1238045, 0);
+    expect(calculateDistanceInMeters(from, to)).toBeCloseTo(1231804, 0);
   });
 
   it("should return 0 for the distance in kilometers for self", () => {
@@ -37,13 +37,13 @@ describe("test distance calculation", () => {
   it("should return the distance between two pots in kilometers", () => {
     const from: Coordinates = dataBank.bc.coordinates;
     const to: Coordinates = dataBank.sk.coordinates;
-    expect(calculateDistanceInKm(from, to)).toBeCloseTo(1238, 0);
+    expect(calculateDistanceInKm(from, to)).toBeCloseTo(1231, 0);
   });
 
   it("should return the distance between two pots in miles", () => {
     const from: Coordinates = dataBank.bc.coordinates;
     const to: Coordinates = dataBank.sk.coordinates;
-    expect(calculateDistanceInMi(from, to)).toBeCloseTo(769, 0);
+    expect(calculateDistanceInMi(from, to)).toBeCloseTo(765, 0);
   });
 });
 

--- a/src/test/utils/utils.test.ts
+++ b/src/test/utils/utils.test.ts
@@ -215,6 +215,50 @@ describe("getDirectionEmoji should return the corresponding emoji for a given Ca
   it("should return ↖️ for ", () => {
     expect(getDirectionEmoji("bc", "yt")).toBe("↖️");
   });
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("ns", "bc")).toBe("↖️");
+  });
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("ns", "nt")).toBe("↖️");
+  });
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("ns", "nb")).toBe("↖️");
+  });
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("ns", "nl")).toBe("↗️");
+  });
+
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("yt", "ns")).toBe("↘️");
+  });
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("yt", "sk")).toBe("↘️");
+  });
+  it("should return ↘️ for yt,mb", () => {
+    expect(getDirectionEmoji("yt", "mb")).toBe("↘️");
+  });
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("yt", "on")).toBe("↘️");
+  });
+
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("mb", "sk")).toBe("⬅️");
+  });
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("mb", "nt")).toBe("↖️");
+  });
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("mb", "nu")).toBe("⬆️");
+  });
+  it("should return ↘️ for mb,ns", () => {
+    expect(getDirectionEmoji("mb", "ns")).toBe("↘️");
+  });
+  it("should return ↘️ for mb,pe", () => {
+    expect(getDirectionEmoji("mb", "pe")).toBe("↘️");
+  });
+  it("should return ↖️ for ", () => {
+    expect(getDirectionEmoji("mb", "on")).toBe("↘️");
+  });
 });
 
 describe("fetchSuggestions filters sanitized substrings", () => {

--- a/src/utils/dataBank.ts
+++ b/src/utils/dataBank.ts
@@ -9,6 +9,7 @@ import { PotCode, PotData, MultiLangName } from "../types/data.ts";
 // - https://www.cntraveler.com/stories/2013-06-10/mount-thor-canada-maphead-ken-jennings
 // - https://history.howstuffworks.com/world-history/canadian-provinces.htm
 // - https://en.wikipedia.org/wiki/List_of_highest_points_of_Canadian_provinces_and_territories
+// - https://www.google.com/maps/search/?api=1&query=<lat>,<lng>
 
 const dataBank: Record<PotCode, PotData> = {
   on: {
@@ -180,7 +181,7 @@ const dataBank: Record<PotCode, PotData> = {
       fr: "Regina",
     },
     coordinates: {
-      latitude: 54,
+      latitude: 54.5,
       longitude: -106.000556,
     },
     population: 1231043,

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,4 +1,5 @@
 import { CardinalDirection, Coordinates } from "../types/data.ts";
+import { latLonToMercator } from "./mercator.ts";
 
 const earthRadiusMeters = 6371e3;
 
@@ -80,7 +81,10 @@ export function toDegrees(radians: number): number {
   return radians * (180 / Math.PI);
 }
 
-export function calculateAngle(pos1: Coordinates, pos2: Coordinates): number {
+export function calculateAngleGeo(
+  pos1: Coordinates,
+  pos2: Coordinates
+): number {
   const lat1 = toRadians(pos1.latitude);
   const lat2 = toRadians(pos2.latitude);
   const deltaLon = toRadians(pos2.longitude - pos1.longitude);
@@ -92,4 +96,15 @@ export function calculateAngle(pos1: Coordinates, pos2: Coordinates): number {
 
   const bearing = Math.atan2(y, x);
   return (toDegrees(bearing) + 360) % 360; // Normalize to 0-360 degrees
+}
+
+export function calculateAngle(pos1: Coordinates, pos2: Coordinates): number {
+  if (pos1 == pos2) {
+    return -1;
+  }
+  const c1 = latLonToMercator(pos1.latitude, pos1.longitude);
+  const c2 = latLonToMercator(pos2.latitude, pos2.longitude);
+  const dx = c2.x - c1.x;
+  const dy = c2.y - c1.y;
+  return Math.floor((toDegrees(Math.atan2(dx, dy)) + 360) % 360);
 }

--- a/src/utils/mercator.ts
+++ b/src/utils/mercator.ts
@@ -1,0 +1,37 @@
+// Constants for the Mercator projection
+const R_MAJOR = 6378137.0;
+const R_MINOR = 6356752.3142;
+const RATIO = R_MINOR / R_MAJOR;
+const ECCENT = Math.sqrt(1.0 - RATIO * RATIO);
+const COM = 0.5 * ECCENT;
+
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+function mercatorX(lon: number): number {
+  return R_MAJOR * toRadians(lon);
+}
+
+function mercatorY(lat: number): number {
+  if (lat > 89.5) lat = 89.5;
+  if (lat < -89.5) lat = -89.5;
+
+  const phi = toRadians(lat);
+  const sinphi = Math.sin(phi);
+  const con = ECCENT * sinphi;
+  const ts =
+    Math.tan(0.5 * (Math.PI * 0.5 - phi)) /
+    Math.pow((1.0 - con) / (1.0 + con), COM);
+  return 0 - R_MAJOR * Math.log(ts);
+}
+
+// Function to convert latitude, longitude to Mercator coordinates
+export function latLonToMercator(
+  lat: number,
+  lon: number
+): { x: number; y: number } {
+  const x = mercatorX(lon);
+  const y = mercatorY(lat);
+  return { x, y };
+}


### PR DESCRIPTION
note: direction between geo coordinate seems to be incorrect when counting the 'shortest flight path' when looking at 'common maps', which can result in weird direction advice.
- see https://en.wikipedia.org/wiki/Great-circle_navigation
Changing to standard rectangular map X,Y coordinates, which is human readable to avoid weird directions eg from Yukon to Nova Scotia (NE vs SE)